### PR TITLE
fix: pass props down to styles

### DIFF
--- a/src/runtime/components/sanity-content.ts
+++ b/src/runtime/components/sanity-content.ts
@@ -111,7 +111,7 @@ function renderStyle (item: Block, serializers: Required<Serializers>, children?
   const { style, listItem } = item
   const serializer = serializers.styles[style]
   const isElement = typeof serializer === 'string'
-  const props = Object.fromEntries(Object.entries(item).filter(([key]) => key !== '_type' && key !== 'markDefs').map(([key, value]) => {
+  const props = Object.fromEntries(Object.entries(item).filter(([key]) => key !== '_type' && key !== 'markDefs' && key !== 'children').map(([key, value]) => {
     if (key === '_key')
       return ['key', value || null]
     if (!isElement || validAttrs.includes(key))

--- a/src/runtime/components/sanity-content.ts
+++ b/src/runtime/components/sanity-content.ts
@@ -63,6 +63,7 @@ const validAttrs = [
   'charset',
   'checked',
   'cite',
+  'class',
   'cols',
   'colspan',
   'command',

--- a/src/runtime/components/sanity-content.ts
+++ b/src/runtime/components/sanity-content.ts
@@ -109,18 +109,19 @@ function findSerializer (item: Block | undefined, serializers: Required<Serializ
 }
 
 function renderStyle (item: Block, serializers: Required<Serializers>, children?: () => Children) {
-  const { style, listItem } = item
-  const serializer = serializers.styles[style]
+  const serializer = item.style && serializers.styles[item.style]
   const isElement = typeof serializer === 'string'
-  const props = Object.fromEntries(Object.entries(item).filter(([key]) => key !== '_type' && key !== 'markDefs' && key !== 'children').map(([key, value]) => {
-    if (key === '_key')
-      return ['key', value || null]
-    if (!isElement || validAttrs.includes(key))
-      return [key, value]
-    return []
-  }))
+  const props = Object.fromEntries(
+    Object.entries(item)
+      .filter(([key]) => key !== '_type' && key !== 'markDefs' && key !== 'children')
+      .map(([key, value]) => {
+        if (key === '_key') return ['key', value || null]
+        if (!isElement || validAttrs.includes(key)) return [key, value]
+        return []
+      }),
+  )
 
-  if (!listItem && style && serializer) {
+  if (!item.listItem && item.style && serializer) {
     return h(serializer as any, props, isVue2 ? children?.() : { default: children })
   }
 

--- a/src/runtime/components/sanity-content.ts
+++ b/src/runtime/components/sanity-content.ts
@@ -107,9 +107,20 @@ function findSerializer (item: Block | undefined, serializers: Required<Serializ
   return item?._type ? serializers.types[item._type] || serializers.marks[item._type] : undefined
 }
 
-function renderStyle ({ style, listItem }: Block, serializers: Required<Serializers>, children?: () => Children) {
-  if (!listItem && style && serializers.styles[style]) {
-    return h(serializers.styles[style] as any, null, isVue2 ? children?.() : { default: children })
+function renderStyle (item: Block, serializers: Required<Serializers>, children?: () => Children) {
+  const { style, listItem } = item
+  const serializer = serializers.styles[style]
+  const isElement = typeof serializer === 'string'
+  const props = Object.fromEntries(Object.entries(item).filter(([key]) => key !== '_type' && key !== 'markDefs').map(([key, value]) => {
+    if (key === '_key')
+      return ['key', value || null]
+    if (!isElement || validAttrs.includes(key))
+      return [key, value]
+    return []
+  }))
+
+  if (!listItem && style && serializer) {
+    return h(serializer as any, props, isVue2 ? children?.() : { default: children })
   }
 
   return children?.()

--- a/test/unit/__snapshots__/sanity-content.test.ts.snap
+++ b/test/unit/__snapshots__/sanity-content.test.ts.snap
@@ -80,4 +80,9 @@ exports[`SanityContent > should render nestedList blocks 1`] = `
 
 exports[`SanityContent > should render strong blocks 1`] = `"<p>An example of <strong>bold</strong> text and <strong>another</strong>.</p>"`;
 
+exports[`SanityContent > should render textWithProps blocks 1`] = `
+"<div>hello worldI’m a heading!</div>
+<blockquote class=\\"blockquote\\">Build your next Vue.js application with confidence using <a href=\\"https://nuxtjs.org\\">NuxtJS</a>. An open source framework making web development simple and powerful.</blockquote>"
+`;
+
 exports[`SanityContent > should render with no props 1`] = `""`;

--- a/test/unit/fixture/portable-text/index.ts
+++ b/test/unit/fixture/portable-text/index.ts
@@ -8,6 +8,7 @@ export * from './mark-defs'
 export * from './nested-list'
 export * from './nested-list-2'
 export * from './strong'
+export * from './text-with-props'
 
 export const link = {
   _type: 'link',

--- a/test/unit/fixture/portable-text/text-with-props.ts
+++ b/test/unit/fixture/portable-text/text-with-props.ts
@@ -1,0 +1,51 @@
+export const textWithProps = [
+  {
+    _key: 'd810da8ac842',
+    _type: 'block',
+    exampleProp: 'hello world',
+    children: [
+      {
+        _key: 'd810da8ac8450',
+        _type: 'span',
+        marks: [],
+        text: 'I’m a heading!',
+      },
+    ],
+    style: 'customStyle1',
+  },
+  {
+    _key: 'd810da8ac843',
+    _type: 'block',
+    class: 'blockquote',
+    children: [
+      {
+        _key: 'd810da8ac8450',
+        _type: 'span',
+        marks: [],
+        text: 'Build your next Vue.js application with confidence using ',
+      },
+      {
+        _key: 'd810da8ac8451',
+        _type: 'span',
+        marks: [
+          'c9c6224401ba',
+        ],
+        text: 'NuxtJS',
+      },
+      {
+        _key: 'd810da8ac8452',
+        _type: 'span',
+        marks: [],
+        text: '. An open source framework making web development simple and powerful.',
+      },
+    ],
+    markDefs: [
+      {
+        _key: 'c9c6224401ba',
+        _type: 'link',
+        href: 'https://nuxtjs.org',
+      },
+    ],
+    style: 'blockquote',
+  },
+]

--- a/test/unit/sanity-content.test.ts
+++ b/test/unit/sanity-content.test.ts
@@ -39,6 +39,9 @@ describe('SanityContent', () => {
                 loader: () => Promise.resolve(CustomBlockComponent),
               }),
             },
+            styles: {
+              customStyle1: CustomBlockComponent,
+            },
           }),
         },
       })


### PR DESCRIPTION
I needed props passed down to my Styles elements and Styles serializers (e.g. p, h2, h3, h4, blockquote, etc.) so I've tweaked this in Sanity Content.



Example use case - previously the below blocks would not render a `class="hello-world"` on `<blockquote />`

```
const blocks = [
  {
    _key: '03ed74fca82b',
    _type: 'block',
    class: 'hello-world',
    children: [],
    markDefs: [],
    style: 'blockquote'
  }
]

<blockquote class="hello-world"></blockquote>
```

I largely copied the code for the existing render() function, only tweak being to filter out markDefs from props.

markDefs aren't required or passed down to the Element - if we wanted to change this, this code could be used:
```
const props = Object.fromEntries(Object.entries(item).filter(([key]) => key !== '_type').map(
    ([key, value]) => {
      if (key === '_key') return ['key', value || null]
      **if (key === 'markDefs') return ['markDefs', value?.length ? value : null]**
      if (!isElement || validAttrs.includes(key)) return [key, value]
      return []
    },
  ))
```