### PR TITLE
docs: update nuxt config examples

### DIFF
--- a/docs/content/1.getting-started/1.quick-start.md
+++ b/docs/content/1.getting-started/1.quick-start.md
@@ -21,9 +21,7 @@ v1 of this module works with Nuxt 3 and Nuxt Bridge. If you are looking for the 
 
 2. **Enable the module in your Nuxt configuration**
 
-   ```js{}[nuxt.config.js]
-   import { defineNuxtConfig } from 'nuxt'
-
+   ```ts{}[nuxt.config.ts]
    export default defineNuxtConfig({
      modules: ['@nuxtjs/sanity']
    })
@@ -33,9 +31,7 @@ v1 of this module works with Nuxt 3 and Nuxt Bridge. If you are looking for the 
 
    This module will look for a `sanity.json` file in your project root directory. You can copy this over from your CMS - and you're fully configured! Alternatively, you can pass in an object in your Nuxt config with key details.
 
-   ```js{}[nuxt.config.js]
-   import { defineNuxtConfig } from 'nuxt'
-
+   ```ts{}[nuxt.config.ts]
    export default defineNuxtConfig({
      modules: ['@nuxtjs/sanity'],
      sanity: {

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -15,9 +15,7 @@ By default, `@nuxtjs/sanity` will look for a `sanity.json` file in your project 
 
 If you need to provide additional configuration, you can pass in an object in your Nuxt config with key details:
 
-```js{}[nuxt.config.js]
-import { defineNuxtConfig } from 'nuxt'
-
+```ts{}[nuxt.config.ts]
 export default defineNuxtConfig({
   modules: ['@nuxtjs/sanity'],
   sanity: {
@@ -33,9 +31,7 @@ It is also possible to pass options to this module through [runtime configuratio
 
 For example:
 
-```js{}[nuxt.config.js]
-import { defineNuxtConfig } from 'nuxt'
-
+```ts{}[nuxt.config.ts]
 export default defineNuxtConfig({
   modules: ['@nuxtjs/sanity'],
   runtimeConfig: {
@@ -132,9 +128,7 @@ The options that can be provided are:
 
 So, for example:
 
-```js{}[nuxt.config.js]
-import { defineNuxtConfig } from 'nuxt'
-
+```ts{}[nuxt.config.ts]
 export default defineNuxtConfig({
   modules: ['@nuxtjs/sanity'],
   sanity: {


### PR DESCRIPTION
It is no longer necessary to explicitly import `defineNuxtConfig`. Also, the Nuxt config-file is now `.ts` by default.