### PR TITLE
fix: use `fetchOptions` in POST requests

### DIFF
--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -73,6 +73,7 @@ export function createClient (config: SanityConfiguration) {
 
       const { result } = usePostRequest
         ? await $fetch<{ result: T }>(urlBase, {
+          ...fetchOptions,
           method: 'post',
           body: { query, params },
         })


### PR DESCRIPTION
For large queries, a POST request is used, but the global request options (e.g. auth token) are not added in this case. If the dataset requires authentication, this causes `useSanityQuery()` to break after a certain query size is reached.