### PR TITLE
docs: update link to `useAsyncData` documentation

### DIFF
--- a/docs/content/1.getting-started/3.usage.md
+++ b/docs/content/1.getting-started/3.usage.md
@@ -9,7 +9,7 @@
 
 ## useSanityQuery
 
-This is a data fetching composable that wraps `useAsyncData` from Nuxt 3 (see [docs](https://v3.nuxtjs.org/docs/usage/data-fetching#useasyncdata)).
+This is a data fetching composable that wraps `useAsyncData` from Nuxt 3 (see [docs](https://nuxt.com/docs/getting-started/data-fetching#useasyncdata)).
 
 The only mandatory argument is the query for it to fetch. You can also pass params, and an options object. In addition to the options you can pass to `useAsyncData`, there is also a `client` option for specifying which configured Sanity client you would like to use.
 


### PR DESCRIPTION
Updated the link to the `useAsyncData` documentation in the `useSanityQuery` [section](https://sanity.nuxtjs.org/getting-started/usage#usesanityquery) as it led to a `404`.

New location: https://nuxt.com/docs/getting-started/data-fetching#useasyncdata