### PR TITLE
fix: send `perspective` as query param when using POST method

### DIFF
--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -80,8 +80,8 @@ export function createClient (config: SanityConfiguration) {
         ? await $fetch<{ result: T }>(urlBase, {
           ...fetchOptions,
           method: 'post',
-          body: { query, params},
-          query: {perspective},
+          body: { query, params },
+          query: { perspective },
         })
         : await $fetch<{ result: T }>(`${urlBase}${qs}`, fetchOptions)
       return result

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -80,7 +80,8 @@ export function createClient (config: SanityConfiguration) {
         ? await $fetch<{ result: T }>(urlBase, {
           ...fetchOptions,
           method: 'post',
-          body: { query, params, perspective },
+          body: { query, params},
+          query: {perspective},
         })
         : await $fetch<{ result: T }>(`${urlBase}${qs}`, fetchOptions)
       return result


### PR DESCRIPTION
This solves #909 and fixes the same [bug](https://github.com/rexxars/picosanity/issues/22) as on [picosanity](https://github.com/rexxars/picosanity) where POSTed queries with a perspective return a 400 error.

**Note on current test setup**: The error is returned from a Sanity server receiving the request. Therefore your current test setup can not detect this error because the `$fetch` function is mocked.
Should we think about refactoring client tests to not mock the `$fetch`?