### PR TITLE
feat: add preview mode helpers and checks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,17 +19,17 @@ declare module 'nuxt/schema' {
     sanity: {
       visualEditing:
         | {
+            mode: SanityVisualEditingMode
             previewMode:
               | false
               | {
                   enable: string
                   disable: string
                 }
-            mode: SanityVisualEditingMode
-            studioUrl: string
             previewModeId: string
+            proxyEndpoint: string
+            studioUrl: string
             token: string
-            
           }
         | undefined
     }
@@ -48,15 +48,16 @@ declare module 'nuxt/schema' {
       useCdn: boolean
       visualEditing:
         | {
+            mode: SanityVisualEditingMode,
             previewMode:
               | false
               | {
                   enable: string
                   disable: string
                 }
-            mode: SanityVisualEditingMode,
-            studioUrl: string
+            proxyEndpoint: string
             refresh: SanityVisualEditingRefreshHandler | undefined,
+            studioUrl: string
             zIndex: SanityVisualEditingZIndex
           }
         | nullish

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,7 +56,7 @@ declare module 'nuxt/schema' {
                 }
             mode: SanityVisualEditingMode,
             studioUrl: string
-            refresh: SanityVisualEditingRefreshHandler,
+            refresh: SanityVisualEditingRefreshHandler | undefined,
             zIndex: SanityVisualEditingZIndex
           }
         | nullish

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,0 +1,4 @@
+<template>
+  <PreviewModeBanner />
+  <NuxtPage />
+</template>

--- a/playground/components/PreviewModeBanner.vue
+++ b/playground/components/PreviewModeBanner.vue
@@ -17,6 +17,7 @@ const shouldShow = computed(() => {
   const visualEditing = ('visualEditing' in sanity && sanity.visualEditing)
 
   // Only show the banner if preview mode is enabled and we are not in Presentation.
+  // @ts-expect-error TODO: fix type testing within repo
   return visualEditing && visualEditing?.isPreviewing.value && !visualEditing.inFrame
 })
 </script>

--- a/playground/components/PreviewModeBanner.vue
+++ b/playground/components/PreviewModeBanner.vue
@@ -17,6 +17,6 @@ const shouldShow = computed(() => {
   const visualEditing = ('visualEditing' in sanity && sanity.visualEditing)
 
   // Only show the banner if preview mode is enabled and we are not in Presentation.
-  return visualEditing && visualEditing?.isPreviewing && !visualEditing.inFrame
+  return visualEditing && visualEditing?.isPreviewing.value && !visualEditing.inFrame
 })
 </script>

--- a/playground/components/PreviewModeBanner.vue
+++ b/playground/components/PreviewModeBanner.vue
@@ -14,12 +14,9 @@ const route = useRoute()
 const sanity = useSanity()
 
 const shouldShow = computed(() => {
-  // Cast type as `visualEditing` is conditionally added to the helper.
-  const visualEditing = ('visualEditing' in sanity && sanity.visualEditing) as
-    | { isPreviewing: boolean; inFrame: () => boolean }
-    | undefined
+  const visualEditing = ('visualEditing' in sanity && sanity.visualEditing)
 
   // Only show the banner if preview mode is enabled and we are not in Presentation.
-  return visualEditing?.isPreviewing && !visualEditing.inFrame()
+  return visualEditing && visualEditing?.isPreviewing && !visualEditing.inFrame
 })
 </script>

--- a/playground/components/PreviewModeBanner.vue
+++ b/playground/components/PreviewModeBanner.vue
@@ -1,0 +1,25 @@
+<template>
+  <a
+    v-if="shouldShow"
+    :href="`/preview/disable?redirect=${route.fullPath}`"
+    class="group fixed bottom-4 right-4 z-50 block rounded bg-white/30 px-3 py-2 text-center text-xs font-medium text-gray-800 shadow-lg backdrop-blur-md hover:bg-red-500 hover:text-white"
+  >
+    <span class="block group-hover:hidden">Preview Enabled</span>
+    <span class="hidden group-hover:block">Disable Preview</span>
+  </a>
+</template>
+
+<script setup lang="ts">
+const route = useRoute()
+const sanity = useSanity()
+
+const shouldShow = computed(() => {
+  // Cast type as `visualEditing` is conditionally added to the helper.
+  const visualEditing = ('visualEditing' in sanity && sanity.visualEditing) as
+    | { isPreviewing: boolean; inFrame: () => boolean }
+    | undefined
+
+  // Only show the banner if preview mode is enabled and we are not in Presentation.
+  return visualEditing?.isPreviewing && !visualEditing.inFrame()
+})
+</script>

--- a/src/module.ts
+++ b/src/module.ts
@@ -317,8 +317,9 @@ export default defineNuxtModule<SanityModuleOptions>({
       // Add auto-imports for visual editing
       if (isNuxt3()) {
         addImports([
-          { name: 'useSanityLiveMode', as: 'useSanityLiveMode', from: composablesFile },
-          { name: 'useSanityVisualEditing', as: 'useSanityVisualEditing', from: composablesFile },
+          { name: 'useSanityLiveMode', from: composablesFile },
+          { name: 'useSanityVisualEditing', from: composablesFile },
+          { name: 'useSanityVisualEditingState', from: composablesFile }
         ])
       }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -339,28 +339,24 @@ export default defineNuxtModule<SanityModuleOptions>({
         logger.info(`Call ${chalk.bold('useSanityVisualEditing()')} in your application to enable visual editing.`)
       }
 
-      const routesDir = join(runtimeDir, 'server/routes')
-
       addServerHandler({
         method: 'post',
         route: visualEditing.proxyEndpoint,
-        handler: join(routesDir, 'proxy'),
+        handler: join(runtimeDir, 'server/routes/proxy'),
       })
 
       if (visualEditing?.previewMode !== false) {
         const previewRoutes = visualEditing.previewMode
 
-        const previewRoutesDir = join(routesDir, 'preview')
-
         addServerHandler({
           method: 'get',
           route: previewRoutes.enable,
-          handler: join(previewRoutesDir, 'enable'),
+          handler: join(runtimeDir, 'server/routes/preview/enable'),
         })
         addServerHandler({
           method: 'get',
           route: previewRoutes.disable,
-          handler: join(previewRoutesDir, 'disable'),
+          handler: join(runtimeDir, 'server/routes/preview/disable'),
         })
 
         logger.info(

--- a/src/module.ts
+++ b/src/module.ts
@@ -319,7 +319,7 @@ export default defineNuxtModule<SanityModuleOptions>({
         addImports([
           { name: 'useSanityLiveMode', from: composablesFile },
           { name: 'useSanityVisualEditing', from: composablesFile },
-          { name: 'useSanityVisualEditingState', from: composablesFile }
+          { name: 'useSanityVisualEditingState', from: composablesFile },
         ])
       }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -346,21 +346,19 @@ export default defineNuxtModule<SanityModuleOptions>({
       })
 
       if (visualEditing?.previewMode !== false) {
-        const previewRoutes = visualEditing.previewMode
-
         addServerHandler({
           method: 'get',
-          route: previewRoutes.enable,
+          route: visualEditing.previewMode.enable,
           handler: join(runtimeDir, 'server/routes/preview/enable'),
         })
         addServerHandler({
           method: 'get',
-          route: previewRoutes.disable,
+          route: visualEditing.previewMode.disable,
           handler: join(runtimeDir, 'server/routes/preview/disable'),
         })
 
         logger.info(
-          `Preview mode enabled. Added routes at: ${Object.values(previewRoutes)
+          `Preview mode enabled. Added routes at: ${Object.values(visualEditing.previewMode)
             .map(route => chalk.bold(route))
             .join(', ')}.`,
         )

--- a/src/runtime/composables/_internal.ts
+++ b/src/runtime/composables/_internal.ts
@@ -1,0 +1,1 @@
+export const useSanityVisualEditingState = () => useState('_sanity_visualEditing', () => false)

--- a/src/runtime/composables/_internal.ts
+++ b/src/runtime/composables/_internal.ts
@@ -1,1 +1,0 @@
-export const useSanityVisualEditingState = () => useState('_sanity_visualEditing', () => false)

--- a/src/runtime/composables/visual-editing.ts
+++ b/src/runtime/composables/visual-editing.ts
@@ -72,8 +72,8 @@ interface _AsyncSanityData<DataT, ErrorT> {
   sourceMap: Ref<ContentSourceMap | null>
   encodeDataAttribute: Ref<EncodeDataAttributeFunction | Noop>
   pending: Ref<boolean>
-  refresh: (opts?: AsyncDataExecuteOptions) => Promise<void>
-  execute: (opts?: AsyncDataExecuteOptions) => Promise<void>
+  refresh: (opts?: AsyncDataExecuteOptions) => Promise<SanityQueryResponse<DataT | null>>
+  execute: (opts?: AsyncDataExecuteOptions) => Promise<SanityQueryResponse<DataT | null>>
   error: Ref<ErrorT | null>
   status: Ref<AsyncDataRequestStatus>
 }

--- a/src/runtime/composables/visual-editing.ts
+++ b/src/runtime/composables/visual-editing.ts
@@ -14,7 +14,8 @@ import type { AsyncData, AsyncDataOptions } from 'nuxt/app'
 import type { ClientConfig, SanityClient } from '../client'
 import type { SanityVisualEditingMode, SanityVisualEditingRefreshHandler, SanityVisualEditingZIndex } from '../../module'
 
-import { createSanityClient, useNuxtApp, useRuntimeConfig, useAsyncData, useState, useRouter, reloadNuxtApp } from '#imports'
+import { createSanityClient, useNuxtApp, useRuntimeConfig, useAsyncData, useRouter, reloadNuxtApp } from '#imports'
+import { useSanityVisualEditingState } from '../composables/_internal'
 
 export interface SanityVisualEditingConfiguration {
   previewMode:
@@ -115,7 +116,7 @@ const createSanityHelper = (
   const { visualEditing, ...clientConfig } = config
   let client = createSanityClient(clientConfig)
 
-  const visualEditingState = useState<boolean>('_sanity_visualEditing')
+  const visualEditingState = useSanityVisualEditingState()
 
   const visualEditingEnabled =
     visualEditing &&

--- a/src/runtime/composables/visual-editing.ts
+++ b/src/runtime/composables/visual-editing.ts
@@ -41,6 +41,10 @@ export interface SanityHelper {
   fetch: SanityClient['fetch']
   setToken: (token: string) => void
   queryStore?: QueryStore
+  visualEditing?: {
+    isPreviewing: Ref<boolean>
+    inFrame: () => boolean | undefined
+  }
 }
 
 export interface VisualEditingProps {
@@ -111,9 +115,11 @@ const createSanityHelper = (
   const { visualEditing, ...clientConfig } = config
   let client = createSanityClient(clientConfig)
 
+  const visualEditingState = useState<boolean>('_sanity_visualEditing')
+
   const visualEditingEnabled =
     visualEditing &&
-    (!visualEditing.previewMode || useState('_sanity_visualEditing').value)
+    (!visualEditing.previewMode || visualEditingState.value)
 
   let queryStore = visualEditingEnabled
     ? createQueryStore(visualEditing, client)
@@ -131,6 +137,14 @@ const createSanityHelper = (
       if (queryStore && visualEditing) {
         queryStore = createQueryStore(visualEditing, client)
       }
+    },
+    visualEditing: {
+      isPreviewing: visualEditingState,
+      inFrame: () => {
+        // Return undefined if on server
+        if (import.meta.server) return undefined;
+        return !!(window.self !== window.top || window.opener)
+      },
     },
   }
 }
@@ -360,4 +374,3 @@ export function useSanityVisualEditing (
 
   return disable
 }
-

--- a/src/runtime/composables/visual-editing.ts
+++ b/src/runtime/composables/visual-editing.ts
@@ -44,7 +44,7 @@ export interface SanityHelper {
   queryStore?: QueryStore
   visualEditing?: {
     isPreviewing: Ref<boolean>
-    inFrame: () => boolean | undefined
+    inFrame: boolean | undefined
   }
 }
 
@@ -141,13 +141,15 @@ const createSanityHelper = (
     },
     visualEditing: {
       isPreviewing: visualEditingState,
-      inFrame: () => {
-        // Return undefined if on server
-        if (import.meta.server) return undefined;
-        return !!(window.self !== window.top || window.opener)
-      },
+      inFrame: isInFrame(),
     },
   }
+}
+
+const isInFrame = () => {
+  // Return undefined if on server
+  if (import.meta.server) return undefined
+  return !!(window.self !== window.top || window.opener)
 }
 
 export const useSanity = (client = 'default'): SanityHelper => {

--- a/src/runtime/composables/visual-editing.ts
+++ b/src/runtime/composables/visual-editing.ts
@@ -131,7 +131,7 @@ const createSanityHelper = (
       if (queryStore && visualEditing) {
         queryStore = createQueryStore(visualEditing, client)
       }
-    }
+    },
   }
 }
 

--- a/src/runtime/composables/visual-editing.ts
+++ b/src/runtime/composables/visual-editing.ts
@@ -72,8 +72,8 @@ interface _AsyncSanityData<DataT, ErrorT> {
   sourceMap: Ref<ContentSourceMap | null>
   encodeDataAttribute: Ref<EncodeDataAttributeFunction | Noop>
   pending: Ref<boolean>
-  refresh: (opts?: AsyncDataExecuteOptions) => Promise<SanityQueryResponse<DataT | null>>
-  execute: (opts?: AsyncDataExecuteOptions) => Promise<SanityQueryResponse<DataT | null>>
+  refresh: (opts?: AsyncDataExecuteOptions) => Promise<void>
+  execute: (opts?: AsyncDataExecuteOptions) => Promise<void>
   error: Ref<ErrorT | null>
   status: Ref<AsyncDataRequestStatus>
 }

--- a/src/runtime/composables/visual-editing.ts
+++ b/src/runtime/composables/visual-editing.ts
@@ -1,5 +1,4 @@
 import { defu } from 'defu'
-import { $fetch } from 'ofetch'
 import { hash } from 'ohash'
 import { onScopeDispose, reactive, ref } from 'vue'
 import { createQueryStore as createCoreQueryStore } from '@sanity/core-loader'

--- a/src/runtime/plugins/visual-editing.client.ts
+++ b/src/runtime/plugins/visual-editing.client.ts
@@ -1,15 +1,14 @@
 // @ts-expect-error need correct typing of #imports
-import { defineNuxtPlugin, useRuntimeConfig, useSanityVisualEditing, useSanityLiveMode, useState } from '#imports'
+import { defineNuxtPlugin, useRuntimeConfig, useSanityVisualEditing, useSanityLiveMode } from '#imports'
+import { useSanityVisualEditingState } from '../composables/_internal'
 
 export default defineNuxtPlugin(() => {
-  const $config = useRuntimeConfig();
-  const { visualEditing } = $config.public.sanity;
-
   // The state value will be true if preview mode is enabled.
   // If preview mode is not enabled, return early.
-  if (!useState('_sanity_visualEditing').value) {
-    return
-  }
+  if (!useSanityVisualEditingState().value) return
+
+  const $config = useRuntimeConfig()
+  const { visualEditing } = $config.public.sanity
 
   if (
     visualEditing?.mode === 'live-visual-editing' ||
@@ -18,10 +17,10 @@ export default defineNuxtPlugin(() => {
     useSanityVisualEditing({
       refresh: visualEditing?.refresh,
       zIndex: visualEditing?.zIndex,
-    });
+    })
   }
 
   if (visualEditing?.mode === 'live-visual-editing') {
-    useSanityLiveMode();
+    useSanityLiveMode()
   }
-});
+})

--- a/src/runtime/plugins/visual-editing.client.ts
+++ b/src/runtime/plugins/visual-editing.client.ts
@@ -1,10 +1,11 @@
 // @ts-expect-error need correct typing of #imports
-import { defineNuxtPlugin, useRuntimeConfig, useSanityVisualEditing, useSanityVisualEditingState, useSanityLiveMode } from '#imports'
+import { defineNuxtPlugin, useRuntimeConfig, useSanityVisualEditing, useSanityLiveMode } from '#imports'
+import { useSanityVisualEditingState } from '../composables/visual-editing'
 
 export default defineNuxtPlugin(() => {
   // The state value will be true if preview mode is enabled.
   // If preview mode is not enabled, return early.
-  if (!useSanityVisualEditingState().value) return
+  if (!useSanityVisualEditingState().enabled) return
 
   const $config = useRuntimeConfig()
   const { visualEditing } = $config.public.sanity

--- a/src/runtime/plugins/visual-editing.client.ts
+++ b/src/runtime/plugins/visual-editing.client.ts
@@ -1,6 +1,5 @@
 // @ts-expect-error need correct typing of #imports
-import { defineNuxtPlugin, useRuntimeConfig, useSanityVisualEditing, useSanityLiveMode } from '#imports'
-import { useSanityVisualEditingState } from '../composables/_internal'
+import { defineNuxtPlugin, useRuntimeConfig, useSanityVisualEditing, useSanityVisualEditingState, useSanityLiveMode } from '#imports'
 
 export default defineNuxtPlugin(() => {
   // The state value will be true if preview mode is enabled.

--- a/src/runtime/plugins/visual-editing.server.ts
+++ b/src/runtime/plugins/visual-editing.server.ts
@@ -1,7 +1,8 @@
-import { defineNuxtPlugin, useRuntimeConfig, useState, useCookie } from '#imports'
+import { defineNuxtPlugin, useRuntimeConfig, useCookie } from '#imports'
+import { useSanityVisualEditingState } from '../composables/_internal'
 
 export default defineNuxtPlugin(() => {
-  const enabled = useState('_sanity_visualEditing', () => false)
+  const enabled = useSanityVisualEditingState()
 
   const $config = useRuntimeConfig()
   const { visualEditing } = $config.sanity

--- a/src/runtime/plugins/visual-editing.server.ts
+++ b/src/runtime/plugins/visual-editing.server.ts
@@ -1,8 +1,8 @@
-// @ts-expect-error useSanityVisualEditingState is conditionally added
-import { defineNuxtPlugin, useRuntimeConfig, useCookie, useSanityVisualEditingState } from '#imports'
+import { defineNuxtPlugin, useRuntimeConfig, useCookie } from '#imports'
+import { useSanityVisualEditingState } from '../composables/visual-editing'
 
 export default defineNuxtPlugin(() => {
-  const enabled = useSanityVisualEditingState()
+  const visualEditingState = useSanityVisualEditingState()
 
   const $config = useRuntimeConfig()
   const { visualEditing } = $config.sanity
@@ -12,9 +12,9 @@ export default defineNuxtPlugin(() => {
   // editing is enabled.
   if (visualEditing?.previewMode) {
     const previewModeCookie = useCookie('__sanity_preview')
-    enabled.value = previewModeCookie.value === visualEditing.previewModeId
+    visualEditingState.enabled = previewModeCookie.value === visualEditing.previewModeId
   // If preview mode is _not_ configured, just enable visual editing.
   } else if (typeof visualEditing === 'object' && !visualEditing.previewMode) {
-    enabled.value = true
+    visualEditingState.enabled = true
   }
 })

--- a/src/runtime/plugins/visual-editing.server.ts
+++ b/src/runtime/plugins/visual-editing.server.ts
@@ -1,5 +1,5 @@
-import { defineNuxtPlugin, useRuntimeConfig, useCookie } from '#imports'
-import { useSanityVisualEditingState } from '../composables/_internal'
+// @ts-expect-error useSanityVisualEditingState is conditionally added
+import { defineNuxtPlugin, useRuntimeConfig, useCookie, useSanityVisualEditingState } from '#imports'
 
 export default defineNuxtPlugin(() => {
   const enabled = useSanityVisualEditingState()

--- a/src/runtime/server/routes/proxy.ts
+++ b/src/runtime/server/routes/proxy.ts
@@ -6,8 +6,8 @@ export default defineEventHandler(async event => {
   const $config = useRuntimeConfig()
   const sanity = useSanity()
 
-  const { query, params = {}, options } = await readBody(event);
-  const previewModeCookie = getCookie(event, "__sanity_preview");
+  const { query, params = {}, options } = await readBody(event)
+  const previewModeCookie = getCookie(event, '__sanity_preview')
 
   const { visualEditing } = $config.sanity
 
@@ -22,6 +22,6 @@ export default defineEventHandler(async event => {
     token: visualEditing.token,
     useCdn: false,
   })
-  
+
   return await client.fetch(query, params, options)
 })

--- a/src/runtime/server/routes/proxy.ts
+++ b/src/runtime/server/routes/proxy.ts
@@ -1,0 +1,27 @@
+import { createError, defineEventHandler, readBody, getCookie } from 'h3'
+
+import { useSanity, useRuntimeConfig } from '#imports'
+
+export default defineEventHandler(async event => {
+  const $config = useRuntimeConfig()
+  const sanity = useSanity()
+
+  const { query, params = {}, options } = await readBody(event);
+  const previewModeCookie = getCookie(event, "__sanity_preview");
+
+  const { visualEditing } = $config.sanity
+
+  if (!visualEditing || previewModeCookie !== visualEditing.previewModeId) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'This endpoint should only be used for fetching preview mode data',
+    })
+  }
+
+  const client = sanity.client.withConfig({
+    token: visualEditing.token,
+    useCdn: false,
+  })
+  
+  return await client.fetch(query, params, options)
+})


### PR DESCRIPTION
This PR adds a few things based on some initial feedback:

- 3fc4791 adds a `visualEditing` property to `SanityHelper` (if visual editing is enabled). The value of this property is an object with two helpers for determining the visual editing context: whether or not visual editing is enabled, and if the app is currently in a frame, i.e. in Presentation. See the playground `PreviewModeBanner.vue` component for how these might be used.
- 1e65afc fixes the missing preview mode check on the client.
- f5ad5e4 fixes the redirect parameter not being respected when disabling preview mode.

LMK if I should split these up into separate PRs.

resolves https://github.com/nuxt-modules/sanity/issues/969