### PR TITLE
fix: add missing `useState` import

### DIFF
--- a/src/runtime/composables/visual-editing.ts
+++ b/src/runtime/composables/visual-editing.ts
@@ -14,7 +14,7 @@ import type { AsyncData, AsyncDataOptions } from 'nuxt/app'
 import type { ClientConfig, SanityClient } from '../client'
 import type { SanityVisualEditingMode, SanityVisualEditingRefreshHandler, SanityVisualEditingZIndex } from '../../module'
 
-import { createSanityClient, useNuxtApp, useRuntimeConfig, useAsyncData, useRouter, reloadNuxtApp } from '#imports'
+import { createSanityClient, useNuxtApp, useRuntimeConfig, useAsyncData, useRouter, useState, reloadNuxtApp } from '#imports'
 
 export interface SanityVisualEditingConfiguration {
   mode: SanityVisualEditingMode,


### PR DESCRIPTION
When consuming the module externally, I see:

`ReferenceError: useState is not defined at useSanityVisualEditingState`

Assuming this is due to a missing import.