### PR TITLE
Add types to docs

### DIFF
--- a/docs/content/1.getting-started/3.usage.md
+++ b/docs/content/1.getting-started/3.usage.md
@@ -21,9 +21,24 @@ This composable is only available in Nuxt 3. For Bridge, you will need to use `u
 
 ### Example
 
-```ts
+```html [JavaScript]
 const query = groq`*[_type == "post" && topic == $topic][0..10]`
 const { data, refresh } = useSanityQuery(query, { topic: 'News' })
+```
+
+### Using types
+Assumes type of Post with relevant types
+<br/>
+::code-group
+```html[Typescript]
+// data will be typed as Ref<Post | null>
+const query = groq`*[_type == "post" && topic == $topic][0..10]`
+const { data, refresh } = useSanityQuery<Post>(query, { topic: 'News' })
+```
+```html[With default values]
+// data will be typed as Ref<string | string> as a string has been provided as a default value
+const query = groq`*[_type == "post" && topic == $topic][0..10]`
+const { data, refresh } = useSanityQuery<Post, string>(query, { topic: 'News' })
 ```
 
 ## useLazySanityQuery

--- a/docs/content/1.getting-started/3.usage.md
+++ b/docs/content/1.getting-started/3.usage.md
@@ -26,19 +26,12 @@ const query = groq`*[_type == "post" && topic == $topic][0..10]`
 const { data, refresh } = useSanityQuery(query, { topic: 'News' })
 ```
 
-### Using types
-Assumes type of Post with relevant types
-<br/>
-::code-group
-```html[Typescript]
+You can also type the result of your query by passing a generic to `useSanityQuery`:
+
+```ts
 // data will be typed as Ref<Post | null>
 const query = groq`*[_type == "post" && topic == $topic][0..10]`
 const { data, refresh } = useSanityQuery<Post>(query, { topic: 'News' })
-```
-```html[With default values]
-// data will be typed as Ref<string | string> as a string has been provided as a default value
-const query = groq`*[_type == "post" && topic == $topic][0..10]`
-const { data, refresh } = useSanityQuery<Post, string>(query, { topic: 'News' })
 ```
 
 ## useLazySanityQuery

--- a/docs/content/1.getting-started/3.usage.md
+++ b/docs/content/1.getting-started/3.usage.md
@@ -21,7 +21,7 @@ This composable is only available in Nuxt 3. For Bridge, you will need to use `u
 
 ### Example
 
-```html [JavaScript]
+```ts
 const query = groq`*[_type == "post" && topic == $topic][0..10]`
 const { data, refresh } = useSanityQuery(query, { topic: 'News' })
 ```


### PR DESCRIPTION
There is a description of using types in the vue-sanity docs, but not the nuxt ones. Not sure how you would infer type so i have not added that