### PR TITLE
fix: `parse-headers`, `debug` and `async-cache-dedupe` no longer need to be optimized

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -315,14 +315,11 @@ export default defineNuxtModule<SanityModuleOptions>({
       })
       nuxt.options.vite.optimizeDeps = defu(nuxt.options.vite.optimizeDeps, {
         include: [
-          '@nuxtjs/sanity > @sanity/core-loader > async-cache-dedupe',
           '@nuxtjs/sanity > @sanity/visual-editing > @sanity/visual-editing > react-is',
           '@nuxtjs/sanity > @sanity/visual-editing > react',
           '@nuxtjs/sanity > @sanity/visual-editing > react/jsx-runtime',
           '@nuxtjs/sanity > @sanity/visual-editing > react-dom',
           '@nuxtjs/sanity > @sanity/visual-editing > react-dom/client',
-          '@sanity/client > get-it > debug',
-          '@sanity/client > get-it > parse-headers',
           '@sanity/client',
         ],
       })


### PR DESCRIPTION
In `get-it` [v8.4.24](https://github.com/sanity-io/get-it/blob/main/CHANGELOG.md#8424-2024-04-17) we started inlining `parse-headers` and `debug` as it were causing issues with the latest version of `hydrogen`.
The same is true for `@sanity/core-loader` [v1.6.7](https://github.com/sanity-io/visual-editing/blob/main/packages/core-loader/CHANGELOG.md#167-2024-04-17) and `async-cache-dedupe`.

What's the reason for inlining `@sanity/client` btw? It should be [strictly ESM compatible](https://publint.dev/@sanity/client@6.15.20) in its latest version 🤔 