### PR TITLE
fix: send perspective as query param when using GET method

### DIFF
--- a/src/runtime/minimal-client.ts
+++ b/src/runtime/minimal-client.ts
@@ -87,7 +87,10 @@ export function createClient(config: ClientConfig) {
           body: { query, params },
           query: { perspective },
         })
-        : await $fetch<{ result: T }>(`${urlBase}${qs}`, fetchOptions)
+        : await $fetch<{ result: T }>(`${urlBase}${qs}`, {
+          ...fetchOptions,
+          query: { perspective },
+        })
       return result
     },
   }

--- a/src/runtime/minimal-client.ts
+++ b/src/runtime/minimal-client.ts
@@ -84,9 +84,9 @@ export function createClient(config: ClientConfig) {
       const { result } = usePostRequest
         ? await $fetch<{ result: T }>(urlBase, {
           ...fetchOptions,
-          query: { perspective },
           method: 'post',
           body: { query, params },
+          query: { perspective },
         })
         : await $fetch<{ result: T }>(`${urlBase}${qs}`, fetchOptions)
       return result

--- a/src/runtime/minimal-client.ts
+++ b/src/runtime/minimal-client.ts
@@ -1,3 +1,4 @@
+import type { FetchOptions } from 'ofetch'
 import { $fetch } from 'ofetch'
 
 /**
@@ -46,7 +47,7 @@ export function createClient(config: ClientConfig) {
 
   const useCdn = perspective !== 'previewDrafts' && config.useCdn
 
-  const fetchOptions: RequestInit = {
+  const fetchOptions: FetchOptions<'json'> = {
     headers: {
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
       Accept: 'application/json',

--- a/src/runtime/minimal-client.ts
+++ b/src/runtime/minimal-client.ts
@@ -52,6 +52,7 @@ export function createClient(config: ClientConfig) {
       Accept: 'application/json',
       ...(import.meta.server ? { 'accept-encoding': 'gzip, deflate' } : {}),
     },
+    query: { perspective },
   }
 
   if (import.meta.client) {
@@ -85,12 +86,8 @@ export function createClient(config: ClientConfig) {
           ...fetchOptions,
           method: 'post',
           body: { query, params },
-          query: { perspective },
         })
-        : await $fetch<{ result: T }>(`${urlBase}${qs}`, {
-          ...fetchOptions,
-          query: { perspective },
-        })
+        : await $fetch<{ result: T }>(`${urlBase}${qs}`, fetchOptions)
       return result
     },
   }

--- a/src/runtime/minimal-client.ts
+++ b/src/runtime/minimal-client.ts
@@ -1,4 +1,3 @@
-import type { FetchOptions } from 'ofetch'
 import { $fetch } from 'ofetch'
 
 /**
@@ -47,7 +46,7 @@ export function createClient(config: ClientConfig) {
 
   const useCdn = perspective !== 'previewDrafts' && config.useCdn
 
-  const fetchOptions: FetchOptions<'json'> = {
+  const fetchOptions: RequestInit = {
     headers: {
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
       Accept: 'application/json',

--- a/src/runtime/minimal-client.ts
+++ b/src/runtime/minimal-client.ts
@@ -53,7 +53,6 @@ export function createClient(config: ClientConfig) {
       Accept: 'application/json',
       ...(import.meta.server ? { 'accept-encoding': 'gzip, deflate' } : {}),
     },
-    query: { perspective },
   }
 
   if (import.meta.client) {
@@ -75,7 +74,7 @@ export function createClient(config: ClientConfig) {
      * Perform a fetch using GROQ syntax.
      */
     async fetch<T = unknown>(query: string, params?: Record<string, unknown>) {
-      const qs = getQuery(query, params)
+      const qs = getQuery(query, params) + `&perspective=${perspective}`
       const usePostRequest = getByteSize(qs) > 9000
 
       const host = useCdn && !usePostRequest ? cdnHost : apiHost
@@ -85,6 +84,7 @@ export function createClient(config: ClientConfig) {
       const { result } = usePostRequest
         ? await $fetch<{ result: T }>(urlBase, {
           ...fetchOptions,
+          query: { perspective },
           method: 'post',
           body: { query, params },
         })

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -47,7 +47,7 @@ describe('minimal sanity client', () => {
     client.fetch('*[_type == "article"')
 
     expect($fetch).toBeCalledWith(
-      'https://sample-project.api.sanity.io/v1/data/query/undefined?query=*%5B_type%20%3D%3D%20%22article%22',
+      'https://sample-project.api.sanity.io/v1/data/query/undefined?query=*%5B_type%20%3D%3D%20%22article%22&perspective=raw',
       expect.not.objectContaining({ method: 'post' }),
     )
   })
@@ -146,6 +146,38 @@ describe('minimal sanity client', () => {
           Accept: 'application/json',
         },
       },
+    )
+  })
+
+  it('appends perspective to the query with GET request', async () => {
+    const client = createClient({
+      projectId: 'sample-project',
+      apiVersion: '1',
+    })
+    const query = '*[_type == "article"]'
+    await client.fetch(query)
+
+    expect($fetch).toBeCalledWith(
+      `https://${project}.api.sanity.io/v1/data/query/undefined?query=${encodeURIComponent(query)}&perspective=raw`,
+      {
+        credentials: 'omit',
+        headers: {
+          Accept: 'application/json',
+        },
+      },
+    )
+  })
+
+  it('appends perspective to the query with POST request', () => {
+    const client = createClient({
+      projectId: 'sample-project',
+      apiVersion: '1',
+    })
+    client.fetch(largeRequest)
+
+    expect($fetch).toBeCalledWith(
+      'https://sample-project.api.sanity.io/v1/data/query/undefined',
+      expect.objectContaining({ method: 'post', query: { perspective: 'raw' } }),
     )
   })
 })


### PR DESCRIPTION
This is the same issue as here: https://github.com/nuxt-modules/sanity/pull/930 but with GET queries. This appends perspective there as well. 
