### PR TITLE
feat: expose `createSanityDataAttribute` utility

### DIFF
--- a/docs/content/2.helpers/5.visual-editing.md
+++ b/docs/content/2.helpers/5.visual-editing.md
@@ -1,0 +1,21 @@
+# Visual Editing
+
+---
+
+When visual editing is enabled, this module exports a `createSanityDataAttribute` helper function which allows you to manually map content in a component to its source.
+
+It is globally available throughout your project (both within your server routes and your Vue app) via auto-imports.
+
+See the [Sanity documentation](https://www.sanity.io/docs/visual-editing-overlays#cb95b19a0263) for more information.
+
+## Example
+
+```vue
+<template>
+  <h1 :data-sanity="createSanityDataAttribute({
+    id: 'the-godfather',
+    type: 'movie',
+    path: 'title',
+  })">The Godfather</h1>
+</template>
+```

--- a/src/module.ts
+++ b/src/module.ts
@@ -331,6 +331,7 @@ export default defineNuxtModule<SanityModuleOptions>({
           { name: 'useSanityLiveMode', from: composablesFile },
           { name: 'useSanityVisualEditing', from: composablesFile },
           { name: 'useSanityVisualEditingState', from: composablesFile },
+          { name: 'createDataAttribute', from: '@sanity/visual-editing', as: 'createSanityDataAttribute' },
         ])
       }
 


### PR DESCRIPTION
### 🔗 Linked issue

#1043 which was created from this question https://github.com/nuxt-modules/sanity/issues/1007#issuecomment-2285692749

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] ✨ New feature (a non-breaking change that adds functionality)

### 📚 Description

Exposes the `createDataAttribute` utility function exported by `@sanity/visual-editing` as an auto-import for the manual creation of content mappings, and adds a new page to the docs.

The function is aliased as `createSanityDataAttribute` to follow the pattern of the other auto-imports exposed by this module.

See the [Sanity docs](https://www.sanity.io/docs/visual-editing-overlays#cb95b19a0263) for more information about `createDataAttribute`.
