### PR TITLE
fix: allow reactive params in visual editing mode

### DIFF
--- a/src/runtime/composables/visual-editing.ts
+++ b/src/runtime/composables/visual-editing.ts
@@ -1,6 +1,6 @@
 import { defu } from 'defu'
 import { hash } from 'ohash'
-import { onScopeDispose, reactive, ref } from 'vue'
+import { onScopeDispose, reactive, ref, watch } from 'vue'
 import { createQueryStore as createCoreQueryStore } from '@sanity/core-loader'
 import { defineEncodeDataAttribute } from '@sanity/core-loader/encode-data-attribute'
 import { enableVisualEditing } from '@sanity/visual-editing'
@@ -234,7 +234,7 @@ export const useSanityQuery = <T = unknown, E = Error> (
 
       const fetcher = sanity.queryStore!.createFetcherStore<T, E>(
         query,
-        _params,
+        JSON.parse(JSON.stringify(params)),
         undefined,
       )
 
@@ -283,6 +283,7 @@ export const useSanityQuery = <T = unknown, E = Error> (
     // On the client, setup the fetcher
     if (import.meta.client) {
       setupFetcher()
+      if (params) watch(params, () => setupFetcher())
     }
 
     onScopeDispose(unsubscribe)


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`useSanityQuery()` accepts params which are refs or reactive. When enabling Visual Editing, the fetcher throws an error after trying to pass the params through `postMessage()` (refs are unable to be serialized).

This PR sends a properly cloned plain object to core-loader and also watches the params to re-create the fetcher with new values when changed.