### PR TITLE
fix: showing visual editor

### DIFF
--- a/src/runtime/composables/visual-editing.ts
+++ b/src/runtime/composables/visual-editing.ts
@@ -234,7 +234,7 @@ export const useSanityQuery = <T = unknown, E = Error> (
 
       const fetcher = sanity.queryStore!.createFetcherStore<T, E>(
         query,
-        JSON.parse(JSON.stringify(params)),
+        params ? JSON.parse(JSON.stringify(params)) : undefined,
         undefined,
       )
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt-modules/sanity/issues/1114

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a regression with the recent `@nuxtjs/sanity@1.13.2` changes which causes an error when we try to use the visual editor and we use `useSanityQuery` without passing in the second argument (the query params object)

e.g
```ts
const { data: movies, encodeDataAttribute } = await useSanityQuery<QueryResult[]>(query)
```

```
500
"undefined" is not valid JSON
at JSON.parse ()
at setupFetcher (http://localhost:3000/_nuxt/@fs/home/crazypanda/workspaces/nuxt-sanity-visual-editor-example/node_modules/@nuxtjs/sanity/dist/runtime/composables/visual-editing.js?v=ccddcf37:125:14)
at useSanityQuery (http://localhost:3000/_nuxt/@fs/home/crazypanda/workspaces/nuxt-sanity-visual-editor-example/node_modules/@nuxtjs/sanity/dist/runtime/composables/visual-editing.js?v=ccddcf37:155:7)
at http://localhost:3000/_nuxt/app.js:18:98
at withAsyncContext (http://localhost:3000/_nuxt/@fs/home/crazypanda/workspaces/nuxt-sanity-visual-editor-example/node_modules/@vue/runtime-core/dist/runtime-core.esm-bundler.js?v=ccddcf37:3396:19)
at setup (http://localhost:3000/_nuxt/app.js:18:74)
at callWithErrorHandling (http://localhost:3000/_nuxt/@fs/home/crazypanda/workspaces/nuxt-sanity-visual-editor-example/node_modules/@vue/runtime-core/dist/runtime-core.esm-bundler.js?v=ccddcf37:197:19)
at setupStatefulComponent (http://localhost:3000/_nuxt/@fs/home/crazypanda/workspaces/nuxt-sanity-visual-editor-example/node_modules/@vue/runtime-core/dist/runtime-core.esm-bundler.js?v=ccddcf37:7923:25)
at setupComponent (http://localhost:3000/_nuxt/@fs/home/crazypanda/workspaces/nuxt-sanity-visual-editor-example/node_modules/@vue/runtime-core/dist/runtime-core.esm-bundler.js?v=ccddcf37:7884:36)
at mountComponent (http://localhost:3000/_nuxt/@fs/home/crazypanda/workspaces/nuxt-sanity-visual-editor-example/node_modules/@vue/runtime-core/dist/runtime-core.esm-bundler.js?v=ccddcf37:5240:7)
```

This prevents the visual editor from showing up.