### PR TITLE
Update sanity-image.ts: mark as deprecated props maxH, minH, maxW & minW

### DIFF
--- a/src/runtime/components/sanity-image.ts
+++ b/src/runtime/components/sanity-image.ts
@@ -114,19 +114,19 @@ const props = {
    */
   invert: { type: Boolean },
   /**
-   * Maximum height. Specifies size limits giving the backend some freedom in picking a size according to the source image aspect ratio.
+   * @deprecated use `h` with `fit=max` instead
    */
   maxH: { type: [Number, String] },
   /**
-   * Maximum width. Specifies size limits giving the backend some freedom in picking a size according to the source image aspect ratio.
+   * @deprecated use `w` with `fit=max` instead
    */
   maxW: { type: [Number, String] },
   /**
-   * Minimum height. Specifies size limits giving the backend some freedom in picking a size according to the source image aspect ratio.
+   * @deprecated use `h` with `fit=min` instead
    */
   minH: { type: [Number, String] },
   /**
-   * Minimum width. Specifies size limits giving the backend some freedom in picking a size according to the source image aspect ratio.
+   * @deprecated use `w` with `fit=min` instead
    */
   minW: { type: [Number, String] },
   /**


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt-modules/sanity/issues/1226

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

See https://github.com/nuxt-modules/sanity/issues/1226