### PR TITLE
Feat: Implement nuxt image

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -3,7 +3,7 @@ import crypto from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { createJiti } from 'jiti'
 import { createRegExp, exactly } from 'magic-regexp'
-import { addComponentsDir, addImports, addPlugin, addServerHandler, addTemplate, defineNuxtModule, resolvePath, useLogger } from '@nuxt/kit'
+import { addComponentsDir, addImports, addPlugin, addServerHandler, addTemplate, defineNuxtModule, hasNuxtModule, resolvePath, useLogger } from '@nuxt/kit'
 
 import { colors } from 'consola/utils'
 import { join, relative, resolve } from 'pathe'
@@ -106,6 +106,11 @@ export type SanityModuleOptions = Partial<MinimalClientConfig | SanityClientConf
    * @default '~~/cms/sanity.config.ts'
    */
   configFile?: string
+  /**
+   * Internal flag to know if @nuxt/image is enabled
+   * @private
+   */
+  isNuxtImageEnabled?: boolean
 }
 
 export type ModuleOptions = SanityModuleOptions
@@ -129,9 +134,14 @@ export default defineNuxtModule<SanityModuleOptions>({
     disableSmartCdn: false,
     perspective: 'raw',
     withCredentials: false,
+    isNuxtImageEnabled: false,
     configFile: '~~/cms/sanity.config',
   },
   async setup(options, nuxt) {
+    if (hasNuxtModule('@nuxt/image', nuxt)) {
+      (options as SanityModuleOptions).isNuxtImageEnabled = true
+    }
+
     // If explicit configuration is not provided, attempt to load it from `sanity.config.ts`
     if (!options.projectId || !options.dataset) {
       // Register watcher on sanity.config.ts
@@ -203,6 +213,7 @@ export default defineNuxtModule<SanityModuleOptions>({
       token: options.token || '',
       useCdn: options.useCdn ?? true,
       withCredentials: options.withCredentials ?? false,
+      isNuxtImageEnabled: (options as SanityModuleOptions).isNuxtImageEnabled,
     }
 
     /**

--- a/src/runtime/components/sanity-image.ts
+++ b/src/runtime/components/sanity-image.ts
@@ -219,7 +219,6 @@ export default defineComponent({
       return () => h(NuxtImg, {
         ...attrs,
         ...nuxtImgOptions.value,
-        provider: 'sanity',
         src: props.assetId,
       })
     }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -41,8 +41,8 @@ type AsyncDataRequestStatus = 'idle' | 'pending' | 'success' | 'error'
  * Return type of `useSanityQuery`
  * @public
  */
-export type AsyncSanityData<Data, Error> = _AsyncSanityData<Data, Error> &
-  Promise<_AsyncSanityData<Data, Error>>
+export type AsyncSanityData<Data, Error> = _AsyncSanityData<Data, Error>
+  & Promise<_AsyncSanityData<Data, Error>>
 
 /**
  * Utility type for a no-op function
@@ -54,13 +54,13 @@ export type Noop = () => void
  * The environment in which the app is being previewed
  * @public
  */
-export type PreviewEnvironment =
-  | 'checking'
-  | 'presentation-iframe'
-  | 'presentation-window'
-  | 'live'
-  | 'static'
-  | 'unknown'
+export type PreviewEnvironment
+  = | 'checking'
+    | 'presentation-iframe'
+    | 'presentation-window'
+    | 'live'
+    | 'static'
+    | 'unknown'
 
 /**
  * The global sanity helper object
@@ -193,37 +193,43 @@ export type SanityPublicRuntimeConfig = {
       zIndex: SanityVisualEditingZIndex | ''
     }
   withCredentials: boolean
+  /**
+   * Whether `@nuxt/image` is used to render images.
+   * @private
+   * @default false
+   */
+  isNuxtImageEnabled?: boolean
 }
 
 /**
  * Module resolved runtime configuration
  * @public
  */
-export type SanityResolvedConfig =
-  Omit<SanityPublicRuntimeConfig, 'liveContent' | 'visualEditing'>
-  & {
-    liveContent:
-      | null
-      | {
-        browserToken: string
-        serverToken: string | undefined // Private, undefined on public
-      }
-    visualEditing:
-      | null
-      | {
-        mode: SanityVisualEditingMode
-        previewMode:
-          | boolean
-          | {
-            enable?: string
-            disable?: string
-          }
-        previewModeId: string | undefined // Private, undefined on public
-        proxyEndpoint: string
-        studioUrl: string
-        token: string | undefined // Private, undefined on public
-        zIndex: SanityVisualEditingZIndex | null
-      }
-  }
+export type SanityResolvedConfig
+  = Omit<SanityPublicRuntimeConfig, 'liveContent' | 'visualEditing'>
+    & {
+      liveContent:
+        | null
+        | {
+          browserToken: string
+          serverToken: string | undefined // Private, undefined on public
+        }
+      visualEditing:
+        | null
+        | {
+          mode: SanityVisualEditingMode
+          previewMode:
+            | boolean
+            | {
+              enable?: string
+              disable?: string
+            }
+          previewModeId: string | undefined // Private, undefined on public
+          proxyEndpoint: string
+          studioUrl: string
+          token: string | undefined // Private, undefined on public
+          zIndex: SanityVisualEditingZIndex | null
+        }
+    }
 
 export type SanityVisualEditingZIndex = VisualEditingOptions['zIndex']


### PR DESCRIPTION
### 🔗 Linked issue

#162

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This enhances the `SanityImage` component by integrating it with `@nuxt/image`.

When the `@nuxt/image` module is installed, it is automatically used for rendering, enabling image optimizations. If the module is not installed, the component gracefully falls back to using a standard `<img>` tag.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
