### PR TITLE
chore: replace `latest` ranges with caret ranges

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -8,11 +8,11 @@
   "dependencies": {
     "@nuxt/image": "^2.0.0",
     "@nuxtjs/sanity": "latest",
-    "@sanity/client": "latest",
+    "@sanity/client": "^7.24.0",
     "nuxt": "4.4.7",
     "react": "19.2.7",
-    "vue": "latest",
-    "vue-router": "latest"
+    "vue": "^3.5.40",
+    "vue-router": "^5.2.0"
   },
   "engines": {
     "node": "^18.20.4 || ^20.9.0 || ^22.0.0 || >=23.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,7 +183,7 @@ importers:
         specifier: link:..
         version: link:..
       '@sanity/client':
-        specifier: latest
+        specifier: ^7.24.0
         version: 7.24.0
       nuxt:
         specifier: 4.4.7
@@ -192,10 +192,10 @@ importers:
         specifier: 19.2.7
         version: 19.2.7
       vue:
-        specifier: latest
+        specifier: ^3.5.40
         version: 3.5.40(typescript@6.0.3)
       vue-router:
-        specifier: latest
+        specifier: ^5.2.0
         version: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
 
   playground/cms:


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`latest` is a curse and can easily drift, or change wildly on lockfile regeneration