### PR TITLE
docs: document using params for field names

### DIFF
--- a/docs/content/1.getting-started/4.usage.md
+++ b/docs/content/1.getting-started/4.usage.md
@@ -50,7 +50,7 @@ const { data } = await useSanityQuery(articlesQuery, {
 
 The query sorts by title when selected, and falls back to the published date. Passing a field name directly, such as `{ sort: 'publishedAt' }` with `order($sort desc)`, will not work because `$sort` evaluates to the string value `"publishedAt"` for every result.
 
-See the Sanity documentation for more information about [GROQ parameters](https://www.sanity.io/docs/specifications/groq-parameters) and [`select()`](https://www.sanity.io/docs/specifications/groq-functions#select).
+See the Sanity documentation for more information about [GROQ parameters](https://www.sanity.io/docs/specifications/groq-parameters) and [`select()`](https://www.sanity.io/docs/specifications/groq-functions#k298e89c3c8d9).
 
 ### Query Options
 

--- a/docs/content/1.getting-started/4.usage.md
+++ b/docs/content/1.getting-started/4.usage.md
@@ -26,6 +26,32 @@ const query = groq`*[_type == "post" && topic == $topic][0..10]`
 const { data, refresh } = useSanityQuery<Post>(query, { topic: 'News' })
 ```
 
+Parameters can contain values, but they cannot replace field names or the `asc` and `desc` keywords. For dynamic ordering, use `select()` to map a parameter to a set of supported ordering expressions:
+
+```vue
+<script setup lang="ts">
+const sort = ref<'publishedAt' | 'title'>('publishedAt')
+
+const articlesQuery = groq`*[_type == "article"] | order(
+  select(
+    $sort == "title" => title,
+    publishedAt,
+  ) desc
+) {
+  title,
+  publishedAt
+}`
+
+const { data } = await useSanityQuery(articlesQuery, {
+  sort,
+})
+</script>
+```
+
+The query sorts by title when selected, and falls back to the published date. Passing a field name directly, such as `{ sort: 'publishedAt' }` with `order($sort desc)`, will not work because `$sort` evaluates to the string value `"publishedAt"` for every result.
+
+See the Sanity documentation for more information about [GROQ parameters](https://www.sanity.io/docs/specifications/groq-parameters) and [`select()`](https://www.sanity.io/docs/specifications/groq-functions#select).
+
 ### Query Options
 
 You can pass a `queryOptions` object to customise the options sent to the underlying Sanity client fetch call. This allows you to override the automatically resolved options for specific queries.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -22,8 +22,9 @@ The easiest way to use Sanity with Nuxt. Get up and running in minutes with a li
   Get started
   :::
 
-  ::copy-code-input{source="npx nuxi@latest module add sanity"}
-  ::
+  :::copy-code-input{source="npx nuxi@latest module add sanity"}
+  :::
+::
 
 ::u-page-section
 #title


### PR DESCRIPTION
Documents how to use params for dynamic ordering. We could instead just link to the docs and leave it at that, but this seems like the most common use

Closes #1090