### PR TITLE
feat: persist Presentation perspective via onPerspectiveChange

### DIFF
--- a/docs/content/1.getting-started/5.visual-editing.md
+++ b/docs/content/1.getting-started/5.visual-editing.md
@@ -95,6 +95,25 @@ export default defineNuxtConfig({
 
 Each report includes the offending `element`, the `attribute` name (when applicable), the raw `value`, the `cleaned` value it should have been, and the decoded `sanity` edit info when available — pointing at the exact document and field that produced the value.
 
+#### `onPerspectiveChange`
+
+- Type: **function**
+
+An optional callback fired when the Studio perspective changes. By default the module persists the perspective to a cookie so server-side fetches use the same client perspective as Presentation. Providing this callback **replaces** that default.
+
+```ts{}[nuxt.config.ts]
+export default defineNuxtConfig({
+  sanity: {
+    visualEditing: {
+      // ... Visual editing config
+      onPerspectiveChange: (perspective) => {
+        console.log('Studio perspective', perspective)
+      },
+    }
+  },
+})
+```
+
 #### `refresh`
 
 - Type: **function**

--- a/src/module.ts
+++ b/src/module.ts
@@ -27,7 +27,7 @@ import { defu } from 'defu'
 import { genExport } from 'knitwork'
 
 import { findQueriesInSource } from '@sanity/codegen'
-import type { ClientConfig as SanityClientConfig, StegaConfig } from '@sanity/client'
+import type { ClientConfig as SanityClientConfig, ClientPerspective, StegaConfig } from '@sanity/client'
 import type { HistoryRefresh, SuspiciousStegaReport } from '@sanity/visual-editing-standalone'
 import { normalizeQuery } from './runtime/util/normalizeQuery'
 import { name, version } from '../package.json'
@@ -46,6 +46,10 @@ export type SanityVisualEditingRefreshHandler = (
 
 export type SanityVisualEditingOnSuspiciousStega = (
   reports: SuspiciousStegaReport[],
+) => void
+
+export type SanityVisualEditingOnPerspectiveChange = (
+  perspective: ClientPerspective,
 ) => void
 
 export interface SanityModuleVisualEditingOptions {
@@ -104,6 +108,12 @@ export interface SanityModuleVisualEditingOptions {
    * logic — when it isn't provided no scanning runs.
    */
   onSuspiciousStega?: SanityVisualEditingOnSuspiciousStega
+  /**
+   * An optional callback fired when the Studio perspective changes. By default
+   * the module persists the perspective to a cookie so server-side fetches use
+   * the same client perspective. Providing this callback replaces that default.
+   */
+  onPerspectiveChange?: SanityVisualEditingOnPerspectiveChange
   /**
    * The CSS z-index on the root node that renders overlays
    * @default 9999999
@@ -641,6 +651,7 @@ export default defineNuxtModule<SanityModuleOptions>({
         getContents: () => `
             export const sanityVisualEditingRefresh = ${options.visualEditing?.refresh?.toString() || 'undefined'}
             export const sanityVisualEditingOnSuspiciousStega = ${options.visualEditing?.onSuspiciousStega?.toString() || 'undefined'}
+            export const sanityVisualEditingOnPerspectiveChange = ${options.visualEditing?.onPerspectiveChange?.toString() || 'undefined'}
           `,
         write: true,
       })
@@ -650,6 +661,7 @@ export default defineNuxtModule<SanityModuleOptions>({
         { name: 'createDataAttribute', from: '@sanity/visual-editing-standalone', as: 'createSanityDataAttribute' },
         { name: 'sanityVisualEditingRefresh', from: '#build/sanity-visual-editing-refresh.mjs' },
         { name: 'sanityVisualEditingOnSuspiciousStega', from: '#build/sanity-visual-editing-refresh.mjs' },
+        { name: 'sanityVisualEditingOnPerspectiveChange', from: '#build/sanity-visual-editing-refresh.mjs' },
         { name: 'useSanityLiveMode', from: join(runtimeDir, 'composables/useSanityLiveMode') },
         { name: 'useSanityVisualEditing', from: join(runtimeDir, 'composables/useSanityVisualEditing') },
       ])

--- a/src/runtime/composables/useSanityPerspective.ts
+++ b/src/runtime/composables/useSanityPerspective.ts
@@ -3,6 +3,7 @@ import { perspectiveCookieName } from '@sanity/preview-url-secret/constants'
 import { computed } from 'vue'
 import { useCookie } from '#imports'
 import { useSanityVisualEditingState } from './useSanityVisualEditingState'
+import { getPreviewStateCookieOptions } from '../constants'
 
 function isValidPerspective(perspective: unknown, allowRaw: false): perspective is Exclude<ClientPerspective, 'raw'>
 function isValidPerspective(perspective: unknown, allowRaw: true): perspective is ClientPerspective
@@ -49,9 +50,7 @@ export const useSanityPerspective = (perspective?: ClientPerspective, fallback?:
   // Not httpOnly, so it can be set from the client
   const cookie = useCookie<ClientPerspective | null>(perspectiveCookieName, {
     default: () => null,
-    sameSite: devMode ? 'lax' : 'none',
-    secure: !devMode,
-    path: '/',
+    ...getPreviewStateCookieOptions(devMode),
   })
 
   return computed<ClientPerspective, unknown>({

--- a/src/runtime/composables/useSanityVisualEditing.ts
+++ b/src/runtime/composables/useSanityVisualEditing.ts
@@ -4,6 +4,7 @@ import type { VisualEditingProps } from '../types'
 import { onScopeDispose } from 'vue'
 import { useRouter, reloadNuxtApp } from '#imports'
 import { useSanityConfig } from './useSanityConfig'
+import { useSanityPerspective } from './useSanityPerspective'
 
 export function useSanityVisualEditing(options: VisualEditingProps = {}) {
   const config = useSanityConfig()
@@ -11,7 +12,9 @@ export function useSanityVisualEditing(options: VisualEditingProps = {}) {
     throw new Error('Configure the `sanity.visualEditing` property in your `nuxt.config.ts` to use the `useSanityVisualEditing` composable. ')
   }
 
-  const { keepStegaOnCopy, onSuspiciousStega, zIndex, refresh } = options
+  const { keepStegaOnCopy, onPerspectiveChange, onSuspiciousStega, zIndex, refresh } = options
+
+  const perspective = useSanityPerspective()
 
   let disable = () => {}
 
@@ -21,6 +24,9 @@ export function useSanityVisualEditing(options: VisualEditingProps = {}) {
       keepStegaOnCopy,
       onSuspiciousStega,
       zIndex,
+      onPerspectiveChange: onPerspectiveChange ?? ((next) => {
+        perspective.value = next
+      }),
       // It is unlikely this API will be used as much by Nuxt users, as
       // implementing fully fledged visual editing is more straightforward
       // compared with other frameworks

--- a/src/runtime/constants.ts
+++ b/src/runtime/constants.ts
@@ -1,1 +1,13 @@
 export const previewCookieName = 'sanity-preview-id'
+
+/**
+ * Cookie flags for preview perspective state. Not httpOnly, so the client can
+ * update them when Presentation changes the perspective.
+ */
+export function getPreviewStateCookieOptions(dev: boolean) {
+  return {
+    path: '/',
+    sameSite: (dev ? 'lax' : 'none') as 'lax' | 'none',
+    secure: !dev,
+  }
+}

--- a/src/runtime/plugins/visual-editing.client.ts
+++ b/src/runtime/plugins/visual-editing.client.ts
@@ -1,5 +1,5 @@
 import { defineNuxtPlugin } from '#imports'
-import { sanityVisualEditingOnSuspiciousStega, sanityVisualEditingRefresh } from '#build/sanity-visual-editing-refresh.mjs'
+import { sanityVisualEditingOnPerspectiveChange, sanityVisualEditingOnSuspiciousStega, sanityVisualEditingRefresh } from '#build/sanity-visual-editing-refresh.mjs'
 import { useSanityConfig } from '../composables/useSanityConfig'
 import { useSanityVisualEditingState } from '../composables/useSanityVisualEditingState'
 import { useSanityVisualEditing } from '../composables/useSanityVisualEditing'
@@ -18,6 +18,7 @@ export default defineNuxtPlugin(async () => {
   ) {
     useSanityVisualEditing({
       keepStegaOnCopy: visualEditing.keepStegaOnCopy || undefined,
+      onPerspectiveChange: sanityVisualEditingOnPerspectiveChange,
       onSuspiciousStega: sanityVisualEditingOnSuspiciousStega,
       refresh: sanityVisualEditingRefresh,
       zIndex: visualEditing.zIndex || undefined,

--- a/src/runtime/server/routes/preview/disable.ts
+++ b/src/runtime/server/routes/preview/disable.ts
@@ -1,8 +1,11 @@
 import { defineEventHandler, deleteCookie, getQuery, sendRedirect } from 'h3'
-import { previewCookieName } from '../../../constants'
+import { perspectiveCookieName } from '@sanity/preview-url-secret/constants'
+import { getPreviewStateCookieOptions, previewCookieName } from '../../../constants'
 
 export default defineEventHandler(async (event) => {
   const { redirect } = getQuery(event)
+  const cookieOptions = getPreviewStateCookieOptions(import.meta.dev)
   deleteCookie(event, previewCookieName)
+  deleteCookie(event, perspectiveCookieName, cookieOptions)
   await sendRedirect(event, redirect?.toString() || '/')
 })

--- a/src/runtime/server/routes/preview/enable.ts
+++ b/src/runtime/server/routes/preview/enable.ts
@@ -1,7 +1,8 @@
 import { createError, defineEventHandler, getRequestURL, setCookie, sendRedirect } from 'h3'
 import { validatePreviewUrl } from '@sanity/preview-url-secret'
+import { perspectiveCookieName } from '@sanity/preview-url-secret/constants'
 import defu from 'defu'
-import { previewCookieName } from '../../../constants'
+import { getPreviewStateCookieOptions, previewCookieName } from '../../../constants'
 import { useSanity, useRuntimeConfig } from '#imports'
 
 export default defineEventHandler(async (event) => {
@@ -14,7 +15,7 @@ export default defineEventHandler(async (event) => {
     token: sanityConfig.visualEditing && 'token' in sanityConfig.visualEditing ? sanityConfig.visualEditing.token : undefined,
   })
 
-  const { isValid, redirectTo = '/' } = await validatePreviewUrl(
+  const { isValid, redirectTo = '/', studioPreviewPerspective } = await validatePreviewUrl(
     client,
     getRequestURL(event).toString(),
   )
@@ -30,12 +31,16 @@ export default defineEventHandler(async (event) => {
     ? sanityConfig.visualEditing.previewModeId
     : undefined as never
 
+  const cookieOptions = getPreviewStateCookieOptions(import.meta.dev)
+
   setCookie(event, previewCookieName, id, {
     httpOnly: true,
-    sameSite: !import.meta.dev ? 'none' : 'lax',
-    secure: !import.meta.dev,
-    path: '/',
+    ...cookieOptions,
   })
+
+  if (studioPreviewPerspective) {
+    setCookie(event, perspectiveCookieName, studioPreviewPerspective, cookieOptions)
+  }
 
   await sendRedirect(event, redirectTo, 307)
 })

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -132,6 +132,7 @@ export interface UseSanityQueryOptions<T> extends AsyncDataOptions<T> {
  */
 export interface VisualEditingProps {
   keepStegaOnCopy?: boolean
+  onPerspectiveChange?: SanityVisualEditingOnPerspectiveChange
   onSuspiciousStega?: SanityVisualEditingOnSuspiciousStega
   refresh?: SanityVisualEditingRefreshHandler
   zIndex?: SanityVisualEditingZIndex
@@ -159,6 +160,14 @@ export type SanityVisualEditingRefreshHandler = (
  */
 export type SanityVisualEditingOnSuspiciousStega = (
   reports: SuspiciousStegaReport[],
+) => void
+
+/**
+ * Handler function for Studio perspective changes
+ * @public
+ */
+export type SanityVisualEditingOnPerspectiveChange = (
+  perspective: ClientPerspective,
 ) => void
 
 export type SanityRuntimeConfig = {

--- a/src/runtime/virtual-modules.d.ts
+++ b/src/runtime/virtual-modules.d.ts
@@ -2,10 +2,11 @@
 // These stubs are used for type checking source files before Nuxt app preparation
 
 declare module '#build/sanity-visual-editing-refresh.mjs' {
-  import type { SanityVisualEditingOnSuspiciousStega, SanityVisualEditingRefreshHandler } from '@nuxtjs/sanity'
+  import type { SanityVisualEditingOnPerspectiveChange, SanityVisualEditingOnSuspiciousStega, SanityVisualEditingRefreshHandler } from '@nuxtjs/sanity'
 
   export const sanityVisualEditingRefresh: SanityVisualEditingRefreshHandler | undefined
   export const sanityVisualEditingOnSuspiciousStega: SanityVisualEditingOnSuspiciousStega | undefined
+  export const sanityVisualEditingOnPerspectiveChange: SanityVisualEditingOnPerspectiveChange | undefined
 }
 
 declare module '@sanity/visual-editing-standalone/styles.css'


### PR DESCRIPTION
## Summary
- Set the perspective cookie from `studioPreviewPerspective` on preview enable, and delete it on disable, using the same cookie flags as `useSanityPerspective`.
- Default `onPerspectiveChange` writes that cookie so the first SSR after preview enable matches Presentation. A user-supplied handler **replaces** the default (same as `refresh`).
- Document `onPerspectiveChange` in the visual editing docs.

Stacked on #1530. After that merges, retarget this PR at `main`.

## Test plan
- [ ] CI: unit tests, types, lint
- [ ] Enable preview from Presentation and confirm the perspective cookie is set before the first SSR
- [ ] Change perspective in Presentation and confirm the cookie updates (default handler)
- [ ] Providing `visualEditing.onPerspectiveChange` replaces the default cookie write
- [ ] Disable preview clears the perspective cookie


Made with [Cursor](https://cursor.com)